### PR TITLE
Project-based docs generation and coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,19 @@ julia:
 notifications:
   email: false
 codecov: true
+
+# deploy documentation
+jobs:
+  include:
+    - stage: Documentation
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
+        - julia --project=docs --color=yes docs/make.jl
+      after_success: skip
+
+# submit coverage
+after_success:
+  - julia --project=test/coverage -e 'using Pkg; Pkg.instantiate()'
+  - julia --project=test/coverage test/coverage/coverage.jl

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ notifications:
 codecov: true
 
 # deploy documentation
-jobs:
-  include:
-    - stage: Documentation
-      julia: 1.0
-      os: linux
-      script:
-        - julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
-        - julia --project=docs --color=yes docs/make.jl
-      after_success: skip
+# jobs:
+#   include:
+#     - stage: Documentation
+#       julia: 1.1
+#       os: linux
+#       script:
+#         - julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
+#         - julia --project=docs --color=yes docs/make.jl
+#       after_success: skip
 
 # submit coverage
 after_success:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.21"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JuliennedArrays = "5cadff95-7770-533d-a838-a1bf817ee6e0"
 
 [compat]
 Documenter = "~0.21"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,13 @@
+using Documenter, JuliennedArrays
+
+makedocs(
+    modules = JuliennedArrays,
+    checkdocs = :exports,
+    sitename = "JuliennedArrays.jl",
+    pages = Any["index.md"],
+    strict = true
+)
+
+deploydocs(
+    repo = "github.com/bramtayl/JuliennedArrays.jl.git",
+)

--- a/test/coverage/Project.toml
+++ b/test/coverage/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"

--- a/test/coverage/coverage.jl
+++ b/test/coverage/coverage.jl
@@ -1,0 +1,9 @@
+# only push coverage from one bot
+get(ENV, "TRAVIS_OS_NAME", nothing)       == "linux" || exit(0)
+get(ENV, "TRAVIS_JULIA_VERSION", nothing) == "1.1"   || exit(0)
+
+using Coverage
+
+cd(joinpath(@__DIR__, "..", "..")) do
+    Codecov.submit(Codecov.process_folder())
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,1 @@
 using JuliennedArrays
-using Documenter: makedocs, deploydocs
-
-makedocs(
-    sitename = "JuliennedArrays.jl",
-    strict = true
-)
-
-deploydocs(
-    repo = "github.com/bramtayl/JuliennedArrays.jl.git",
-)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,1 +1,12 @@
 using JuliennedArrays
+
+# Build the docs on Julia v1.1
+if get(ENV, "TRAVIS_JULIA_VERSION", nothing) == "1.1"
+    cd(joinpath(@__DIR__, "..")) do
+        withenv("JULIA_LOAD_PATH" => nothing) do
+            cmd = `$(Base.julia_cmd()) --depwarn=no --color=yes --project=docs/`
+            run(`$(cmd) -e 'using Pkg; Pkg.instantiate()'`)
+            run(`$(cmd) docs/make.jl`)
+        end
+    end
+end


### PR DESCRIPTION
1. Use Julia 1.1 with a project file for coverage

2. Use project for documentation deployment, call from travis
directly. Pin Documenter version to protect agains API changes.

Fixes #10.