### PR TITLE
submit coverage by script, move test/REQUIRE into project file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,6 @@ julia:
   - nightly
 notifications:
   email: false
-codecov: true
+after_success:
+  - julia --project=test/coverage -e 'using Pkg; Pkg.instantiate()'
+  - julia --project=test/coverage test/coverage/coverage.jl

--- a/Project.toml
+++ b/Project.toml
@@ -1,3 +1,13 @@
 name = "JuliennedArrays"
 uuid = "5cadff95-7770-533d-a838-a1bf817ee6e0"
 authors = ["Brandon Taylor <brandon.taylor221@gmail.com>"]
+
+[extras]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test", "Documenter"]
+
+[compat]
+Documenter = "~0.21"

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-Documenter

--- a/test/coverage/Project.toml
+++ b/test/coverage/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"

--- a/test/coverage/coverage.jl
+++ b/test/coverage/coverage.jl
@@ -1,0 +1,9 @@
+# only push coverage from one bot
+get(ENV, "TRAVIS_OS_NAME", nothing)       == "linux" || exit(0)
+get(ENV, "TRAVIS_JULIA_VERSION", nothing) == "1.1"   || exit(0)
+
+using Coverage
+
+cd(joinpath(@__DIR__, "..", "..")) do
+    Codecov.submit(Codecov.process_folder())
+end


### PR DESCRIPTION
Coverage submitted for 1.1 (currently provides much better line
coverage than 1.0).

test/REQUIRE contents moved to Project.toml.

Pin Documenter version (as recommended).