### PR TITLE
One-argument Align

### DIFF
--- a/src/JuliennedArrays.jl
+++ b/src/JuliennedArrays.jl
@@ -191,7 +191,7 @@ split_indices(aligned, indices) =
     getindex_unrolled(indices, map_unrolled(not, aligned.alongs)),
     getindex_unrolled(indices, aligned.alongs)
 @propagate_inbounds function getindex(aligned::Align, indices::Int...)
-    outer, inner = split_indices(aligned, indices)
+    outer, inner = split_indices(aligned, indices[1:min(end,ndims(aligned))])
     aligned.slices[outer...][inner...]
 end
 @propagate_inbounds function setindex!(aligned::Align, value, indices::Int...)

--- a/src/JuliennedArrays.jl
+++ b/src/JuliennedArrays.jl
@@ -1,6 +1,6 @@
 module JuliennedArrays
 
-import Base: axes, getindex, setindex!, size
+import Base: axes, getindex, setindex!, size, parent
 using Base: promote_op, @pure, @propagate_inbounds, tail
 
 map_unrolled(call, variables::Tuple{}) = ()
@@ -76,6 +76,7 @@ Slices{Item, Dimensions}(whole::Whole, alongs::Alongs) where {Item, Dimensions, 
 axes(slices::Slices) =
     getindex_unrolled(axes(slices.whole), map_unrolled(not, slices.alongs))
 size(slices::Slices) = map_unrolled(length, axes(slices))
+parent(slices::Slices) = slices.whole
 
 slice_index(slices, indices) = setindex_unrolled(
     axes(slices.whole),

--- a/src/JuliennedArrays.jl
+++ b/src/JuliennedArrays.jl
@@ -234,6 +234,7 @@ export Align
     Along(slices, alongs::Int...)
 
 Alternative syntax: `alongs` is which dimensions will be taken up by the inner arrays.
+If none are given, the default is `1, 2, ..., ndims(first(slices))`.
 
 ```jldoctest
 julia> using JuliennedArrays
@@ -271,3 +272,6 @@ Align(slices::AbstractArray{<:AbstractArray{Item, InnerDimensions}, OuterDimensi
     )...)
 
 end
+
+Align(slices::AbstractArray{<:AbstractArray{Item, InnerDimensions}, OuterDimensions}) where {Item, InnerDimensions, OuterDimensions} =
+    Align(slices, ntuple(_ -> True(), InnerDimensions)..., ntuple(_ -> False(), OuterDimensions)...)


### PR DESCRIPTION
I think it would be handy if `Align()` had a default, but right now this is an error:
```
julia> Align([ n .* ones(Int,2) for n=1:3 ])
ERROR: MethodError: Align(::Array{Array{Int64,1},1}) is ambiguous. Candidates:
  (::Type{Align})(slices::AbstractArray{...}, alongs::Int64...) where {...} ...
  (::Type{Align})(slices::AbstractArray{...}, alongs::JuliennedArrays.TypedBool...) where {...} ...
```

Independently, it would be nice if `parent(S::Slices) = S.whole`; this is true for all the lazy wrappers in `Base`, and useful for recursively unwrapping things. I can separate it from the above if you wish.